### PR TITLE
Fix: Align server behavior with integration tests

### DIFF
--- a/server/src/controllers/quote.controller.ts
+++ b/server/src/controllers/quote.controller.ts
@@ -22,7 +22,22 @@ export const getAllQuotesHandler = async (request: Request, db: D1Database) => {
   const end = Number.parseInt(url.searchParams.get("_end") || "10", 10);
   const limit = end - start;
   const offset = start;
-  const categoryId = url.searchParams.get("categoryId") || "0";
+  const categoryIdStr = url.searchParams.get("categoryId");
+
+  // Validate categoryId format if it exists
+  if (categoryIdStr && !/^\d+$/.test(categoryIdStr)) {
+    return Response.json(
+      { error: "Invalid categoryId format" },
+      {
+        status: 400,
+        headers: DEFAULT_CORS_HEADERS,
+      },
+    );
+  }
+
+  // Use the validated categoryId or default to 0 if not provided
+  const categoryId = categoryIdStr ? Number.parseInt(categoryIdStr, 10) : 0;
+
   const options = {
     pagination: {
       limit,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,35 +58,44 @@ export default {
       return getQuoteOfTheDayHandler(request, env);
     }
 
-    // --- Authentication Middleware ---
+    // --- Routes Requiring Only Authentication ---
 
+    // GET /quotes
+    if (url.pathname === "/quotes" && request.method === "GET") {
+      try {
+        await authenticationMiddleware(request, env, ctx);
+        return getAllQuotesHandler(request, env.DB);
+      } catch {
+        return Response.json(
+          { error: "Unauthorized", message: "Authentication required." },
+          { status: 401, headers: DEFAULT_CORS_HEADERS },
+        );
+      }
+    }
+
+    // --- Routes Requiring Authentication + Admin Role ---
+
+    // Apply Authentication Middleware globally for remaining routes
     try {
       await authenticationMiddleware(request, env, ctx);
     } catch {
       return Response.json(
-        {
-          error: "Unauthorized",
-          message: "Authentication failed.",
-        },
-        { status: 401 },
+        { error: "Unauthorized", message: "Authentication failed." },
+        { status: 401, headers: DEFAULT_CORS_HEADERS },
       );
     }
 
-    // Regular authenticated user
-
+    // Apply Admin Check globally for remaining routes
     if (!(await isAdmin(ctx))) {
       return Response.json(
-        {
-          error: "Forbidden",
-          message: "You do not have permission to perform this action.",
-        },
-        { status: 403 },
+        { error: "Forbidden", message: "Admin privileges required." },
+        { status: 403, headers: DEFAULT_CORS_HEADERS },
       );
     }
 
-    // Admin authenticated user
-
+    // --- Admin-Only Routes ---
     try {
+      // POST /categories
       if (url.pathname === "/categories" && request.method === "POST") {
         try {
           const requestBody = await request.json<CategoryInput>();
@@ -99,57 +108,89 @@ export default {
         }
       }
 
+      // /categories/:id (PUT, DELETE, GET - GET needs admin here?)
+      // Note: The original code had GET /categories/:id here, implying it needed admin.
+      // Keeping it here for now, but it might be better public or just authenticated.
       if (url.pathname.startsWith("/categories/")) {
-        const categoryId: number = Number.parseInt(url.pathname.split("/")[2]);
+        const categoryIdStr = url.pathname.split("/")[2];
+        if (!/^\d+$/.test(categoryIdStr)) {
+          return Response.json({ error: "Invalid category ID format" }, { status: 400, headers: DEFAULT_CORS_HEADERS });
+        }
+        const categoryId = Number.parseInt(categoryIdStr, 10);
+
         switch (request.method) {
-          case "PATCH":
+          case "PATCH": // Assuming PATCH is like PUT
           case "PUT": {
-            const requestBody = await request.json<CategoryInput>();
-            if (!requestBody.name) {
-              return Response.json("Invalid request body", { status: 400 });
+            try {
+              const requestBody = await request.json<CategoryInput>();
+              // Basic validation, can be improved
+              if (!requestBody || typeof requestBody.name !== 'string' || requestBody.name.trim() === '') {
+                 return Response.json("Invalid request body: 'name' is required and must be a non-empty string.", { status: 400, headers: DEFAULT_CORS_HEADERS });
+              }
+              return updateCategoryHandler(env.DB, categoryId, requestBody);
+            } catch (e) {
+               return Response.json("Invalid JSON", { status: 400, headers: DEFAULT_CORS_HEADERS });
             }
-            return updateCategoryHandler(env.DB, categoryId, requestBody);
           }
-          case "GET":
+          case "GET": // Requires admin in this block
             return getCategoryByIdHandler(env.DB, categoryId);
           case "DELETE":
             return deleteCategoryHandler(env.DB, categoryId);
         }
       }
 
-      if (url.pathname === "/quotes") {
-        switch (request.method) {
-          case "GET":
-            return getAllQuotesHandler(request, env.DB);
-          case "POST":
-            try {
-              const requestBody = await request.json<QuoteInput>();
-              return createQuoteHandler(env.DB, requestBody);
-            } catch {
-              return Response.json("Invalid JSON", {
-                status: 400,
-                headers: DEFAULT_CORS_HEADERS,
-              });
-            }
+      // POST /quotes
+      if (url.pathname === "/quotes" && request.method === "POST") {
+        try {
+          const requestBody = await request.json<QuoteInput>();
+           // Basic validation, can be improved
+           if (!requestBody || typeof requestBody.quote !== 'string' || requestBody.quote.trim() === '' ||
+               typeof requestBody.author !== 'string' || requestBody.author.trim() === '' ||
+               typeof requestBody.categoryId !== 'number') {
+                 return Response.json("Invalid request body: 'quote', 'author', and 'categoryId' are required.", { status: 400, headers: DEFAULT_CORS_HEADERS });
+           }
+          return createQuoteHandler(env.DB, requestBody);
+        } catch {
+          return Response.json("Invalid JSON", {
+            status: 400,
+            headers: DEFAULT_CORS_HEADERS,
+          });
         }
       }
 
-      if (url.pathname.startsWith("/quotes/")) {
-        const quoteId: number = Number.parseInt(url.pathname.split("/")[2]);
-        switch (request.method) {
-          case "PATCH":
-          case "PUT": {
-            const requestBody = await request.json<QuoteInput>();
-            return updateQuoteHandler(env.DB, quoteId, requestBody);
-          }
-          case "GET":
-            return getQuoteByIdHandler(env.DB, quoteId);
-          case "DELETE":
-            return deleteQuoteHandler(env.DB, quoteId);
-        }
-      }
+      // /quotes/:id (PUT, DELETE, GET - GET needs admin here?)
+      // Note: The original code had GET /quotes/:id here. Keeping it admin-only.
+       if (url.pathname.startsWith("/quotes/")) {
+         const quoteIdStr = url.pathname.split("/")[2];
+         if (!/^\d+$/.test(quoteIdStr)) {
+           return Response.json({ error: "Invalid quote ID format" }, { status: 400, headers: DEFAULT_CORS_HEADERS });
+         }
+         const quoteId = Number.parseInt(quoteIdStr, 10);
+
+         switch (request.method) {
+           case "PATCH": // Assuming PATCH is like PUT
+           case "PUT": {
+             try {
+               const requestBody = await request.json<QuoteInput>();
+               // Basic validation, can be improved
+               if (!requestBody || typeof requestBody.quote !== 'string' || requestBody.quote.trim() === '' ||
+                   typeof requestBody.author !== 'string' || requestBody.author.trim() === '' ||
+                   typeof requestBody.categoryId !== 'number') {
+                  return Response.json("Invalid request body: 'quote', 'author', and 'categoryId' are required.", { status: 400, headers: DEFAULT_CORS_HEADERS });
+               }
+               return updateQuoteHandler(env.DB, quoteId, requestBody);
+             } catch (e) {
+               return Response.json("Invalid JSON", { status: 400, headers: DEFAULT_CORS_HEADERS });
+             }
+           }
+           case "GET": // Requires admin in this block
+             return getQuoteByIdHandler(env.DB, quoteId);
+           case "DELETE":
+             return deleteQuoteHandler(env.DB, quoteId);
+         }
+       }
     } catch (error) {
-      console.error("Error handling request:", error);
+      console.error("Error handling admin request:", error);
       return Response.json(
         {
           error: "Internal Server Error",


### PR DESCRIPTION
I modified the server implementation to ensure all integration tests in `test/integration-tests` pass.

Key changes:

- **Routing & Authorization:**
    - I applied `authenticationMiddleware` and `isAdmin` checks to CUD operations (`POST`, `PUT`, `DELETE`) for both `/categories` and `/quotes` routes in `server/src/index.ts`. This ensures only authenticated admin users can perform these actions.
    - I applied only `authenticationMiddleware` to `GET /quotes`, allowing any authenticated user (admin or regular) to fetch quotes.
    - I confirmed `GET /categories`, `GET /qotd`, and `GET /random` routes remain public (no authentication required).
    - I added basic request body validation and ID format checks to admin routes for robustness.

- **Input Validation:**
    - I modified `getAllQuotesHandler` in `server/src/controllers/quote.controller.ts` to validate the `categoryId` query parameter. It returns a 400 Bad Request if the parameter is present but not a valid integer string.

These changes address discrepancies I identified by comparing server behavior against the integration test suite, ensuring the API enforces the intended access control and input validation rules.