### PR TITLE
Fix(server): Correct quote API validation and delete behavior

### DIFF
--- a/server/src/controllers/quote.controller.ts
+++ b/server/src/controllers/quote.controller.ts
@@ -176,11 +176,30 @@ export const createQuoteHandler = async (
   db: D1Database,
   quote: { quote: string; author: string; categoryId: number },
 ) => {
-  const newQuote = await createQuote(db, quote);
-  return Response.json(newQuote, {
-    status: 201,
-    headers: DEFAULT_CORS_HEADERS,
-  });
+  try {
+    const newQuote = await createQuote(db, quote);
+    return Response.json(newQuote, {
+      status: 201,
+      headers: DEFAULT_CORS_HEADERS,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Invalid quote input") {
+      return Response.json(
+        {
+          error:
+            "Invalid request body: 'quote', 'author', and 'categoryId' are required and must be valid.",
+        },
+        { status: 400, headers: DEFAULT_CORS_HEADERS },
+      );
+    }
+    // Log the error for debugging purposes
+    console.error("Error in createQuoteHandler:", error);
+    // Return a generic 500 error for other types of errors
+    return Response.json(
+      { error: "Internal Server Error" },
+      { status: 500, headers: DEFAULT_CORS_HEADERS },
+    );
+  }
 };
 
 export const updateQuoteHandler = async (
@@ -188,8 +207,40 @@ export const updateQuoteHandler = async (
   id: number,
   quote: { quote: string; author: string; categoryId: number },
 ) => {
-  const updatedQuote = await updateQuote(db, id, quote);
-  if (!updatedQuote) {
+  try {
+    const updatedQuote = await updateQuote(db, id, quote);
+    if (!updatedQuote) {
+      return new Response("Quote not found", {
+        status: 404,
+        headers: DEFAULT_CORS_HEADERS,
+      });
+    }
+    return Response.json(updatedQuote, {
+      headers: DEFAULT_CORS_HEADERS,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Invalid quote input") {
+      return Response.json(
+        {
+          error:
+            "Invalid request body: 'quote', 'author', and 'categoryId' are required and must be valid.",
+        },
+        { status: 400, headers: DEFAULT_CORS_HEADERS },
+      );
+    }
+    // Log the error for debugging purposes
+    console.error("Error in updateQuoteHandler:", error);
+    // Return a generic 500 error for other types of errors
+    return Response.json(
+      { error: "Internal Server Error" },
+      { status: 500, headers: DEFAULT_CORS_HEADERS },
+    );
+  }
+};
+
+export const deleteQuoteHandler = async (db: D1Database, id: number) => {
+  const success = await deleteQuote(db, id);
+  if (!success) {
     return new Response("Quote not found", {
       status: 404,
       headers: DEFAULT_CORS_HEADERS,

--- a/server/src/services/quote.service.ts
+++ b/server/src/services/quote.service.ts
@@ -102,8 +102,8 @@ export const validateQuoteInput = (input: QuoteInput): boolean => {
     !input.author ||
     input.author.trim().length === 0 ||
     input.author.length > 100 ||
-    !input.categoryId ||
-    typeof input.categoryId !== "number"
+    input.categoryId === undefined ||
+    typeof input.categoryId !== 'number'
   );
 };
 
@@ -159,6 +159,13 @@ export const deleteQuote = async (
   db: D1Database,
   id: number,
 ): Promise<boolean> => {
+  // Check if the quote exists before attempting to delete
+  const existingQuote = await getQuoteById(db, id);
+  if (!existingQuote) {
+    return false; // Quote not found, indicate failure
+  }
+
+  // Quote exists, proceed with deletion
   const result = await db
     .prepare("DELETE FROM Quotes WHERE QuoteId = ?")
     .bind(id)


### PR DESCRIPTION
Addresses issues found in integration tests:

- POST /quotes and PUT /quotes/:id now return a 400 status code with a JSON body { "error": "..." } when request body validation fails (e.g., missing categoryId, invalid types, empty quote/author). This is achieved by adding try-catch blocks in the controller handlers to catch validation errors thrown by the service layer.
- The `validateQuoteInput` service function was refined to explicitly check for `undefined` categoryId.
- DELETE /quotes/:id now correctly returns a 404 status code if the quote does not exist. The `deleteQuote` service function was modified to check for the quote's existence before attempting deletion, and the controller handler already correctly returned 404 based on the service's boolean response.